### PR TITLE
Stop relying on internal functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,20 +16,24 @@ const originalMulter = require('multer')
 function multer(options) {
   const m = originalMulter(options)
 
-  const _makeMiddleware = m._makeMiddleware.bind(m)
-  m._makeMiddleware = makePromise(_makeMiddleware)
-
-  const any = m.any.bind(m)
-  m.any = makePromise(any)
+  makePromise(m, 'any')
+  makePromise(m, 'array')
+  makePromise(m, 'fields')
+  makePromise(m, 'none')
+  makePromise(m, 'single')
 
   return m
 }
 
-function makePromise(fn) {
-  return (fields, fileStrategy) => {
+function makePromise(multer, name) {
+  if (!multer[name]) return
+
+  const fn = multer[name].bind(multer)
+
+  multer[name] = (...args) => {
     return (ctx, next) => {
       return new Promise((resolve, reject) => {
-        fn(fields, fileStrategy)(ctx.req, ctx.res, (err) => {
+        fn(...args)(ctx.req, ctx.res, (err) => {
           err ? reject(err) : resolve(ctx)
         })
       }).then(next)

--- a/index.js
+++ b/index.js
@@ -31,11 +31,11 @@ function makePromise(multer, name) {
   const fn = multer[name]
 
   multer[name] = function () {
-    const args = arguments
+    const middleware = fn.apply(this, arguments)
 
     return (ctx, next) => {
       return new Promise((resolve, reject) => {
-        fn.apply(multer, args)(ctx.req, ctx.res, (err) => {
+        middleware(ctx.req, ctx.res, (err) => {
           err ? reject(err) : resolve(ctx)
         })
       }).then(next)

--- a/index.js
+++ b/index.js
@@ -28,12 +28,14 @@ function multer(options) {
 function makePromise(multer, name) {
   if (!multer[name]) return
 
-  const fn = multer[name].bind(multer)
+  const fn = multer[name]
 
-  multer[name] = (...args) => {
+  multer[name] = function () {
+    const args = arguments
+
     return (ctx, next) => {
       return new Promise((resolve, reject) => {
-        fn(...args)(ctx.req, ctx.res, (err) => {
+        fn.apply(multer, args)(ctx.req, ctx.res, (err) => {
           err ? reject(err) : resolve(ctx)
         })
       }).then(next)


### PR DESCRIPTION
I removed `_makeMiddleware` in multer 2.0.0-alpha.1 which broke this module. With this patch we aren't relying on any internal functions, but are instead using only the public api.